### PR TITLE
serve static files from /samples and /src

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -34,8 +34,10 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use(express.static("samples"));
-app.use(express.static("src"));
+
+app.use('/samples', express.static(path.join(__dirname , '../samples')));
+app.use('/src', express.static(path.join(__dirname , "../src")));
+
 
 app.get('/', (req, res) => {
   // res.send('hello world!');


### PR DESCRIPTION
- had to set up static routes
https://expressjs.com/en/starter/static-files.html

To create a virtual path prefix (where the path does not actually exist in the file system) for files that are served by the express.static function, specify a mount path for the static directory, as shown below:

app.use('/static', express.static('public'))